### PR TITLE
fix: 修复以json格式读非纯文本文件的问题

### DIFF
--- a/app/src/main/java/com/xjw/bilifix/in/feature/subtitle/SubtitleFileCompat.java
+++ b/app/src/main/java/com/xjw/bilifix/in/feature/subtitle/SubtitleFileCompat.java
@@ -13,6 +13,10 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.nio.charset.CharacterCodingException;
+import java.nio.charset.CharsetDecoder;
+import java.nio.charset.CodingErrorAction;
 import java.nio.charset.StandardCharsets;
 
 /** Adapts current AI subtitle JSON to the stricter parser bundled with the old client. */
@@ -52,6 +56,10 @@ final class SubtitleFileCompat {
                 return;
             }
             String source = readUtf8(file, sourceBytes);
+            if (source.isBlank()) {
+                return;
+            }
+
             JSONObject root = new JSONObject(source);
             if (!"AIsubtitle".equals(root.optString("type"))) {
                 return;
@@ -84,7 +92,7 @@ final class SubtitleFileCompat {
                     + " patchedLocation=" + patched
                     + " bytes=" + sourceBytes + "->" + normalized.length);
         } catch (Throwable throwable) {
-            module.error("AI subtitle file normalization failed: file=" + file.getName(),
+            module.error("AI subtitle file normalization failed: file=" + file.getAbsolutePath(),
                     throwable);
         }
     }
@@ -101,7 +109,16 @@ final class SubtitleFileCompat {
                     throw new IllegalStateException("subtitle file exceeds size limit");
                 }
             }
-            return output.toString(StandardCharsets.UTF_8.name());
+
+            byte[] data = output.toByteArray();
+            try {
+                CharsetDecoder decoder = StandardCharsets.UTF_8.newDecoder();
+                decoder.onMalformedInput(CodingErrorAction.REPORT);
+                decoder.onUnmappableCharacter(CodingErrorAction.REPORT);
+                return decoder.decode(ByteBuffer.wrap(data)).toString();
+            } catch (CharacterCodingException e) {
+                return "";
+            }
         }
     }
 


### PR DESCRIPTION
修复可能出现的如下报错
```
AI subtitle file normalization failed: file=chronos_file_1

org.json.JSONException: Value �PNG of type java.lang.String cannot be converted to JSONObject
	at org.json.JSON.typeMismatch(JSON.java:112)
	at org.json.JSONObject.<init>(JSONObject.java:172)
	at org.json.JSONObject.<init>(JSONObject.java:185)
	at com.xjw.bilifix.in.feature.subtitle.SubtitleFileCompat.normalize(SubtitleFileCompat.java:55)
	at com.xjw.bilifix.in.feature.subtitle.SubtitleFileCompat.lambda$install$0(SubtitleFileCompat.java:42)
	at com.xjw.bilifix.in.feature.subtitle.SubtitleFileCompat.$r8$lambda$iHWtiovvgCA-4nSl74fw-LmIPUM(Unknown Source:0)
	at com.xjw.bilifix.in.feature.subtitle.SubtitleFileCompat$$ExternalSyntheticLambda0.intercept(D8$$SyntheticClass:0)
	at g2.intercept(r8-map-id-641cd0d9f3f2136e302270e7ebfbbc1eaeb97195335bb6679d8c71628db6c7ea:8)
	at k.proceed(r8-map-id-641cd0d9f3f2136e302270e7ebfbbc1eaeb97195335bb6679d8c71628db6c7ea:33)
	at android.app.Chut.c(Chut.java)
	at com.bilibili.common.chronoscommon.plugins.e.a(BL:57)
	at com.bilibili.common.chronoscommon.plugins.e.convert(BL:3)
	at rx1.a.r(BL:123)
	at rx1.a.execute(BL:358)
	at rx1.a$a.run(BL:8)
```